### PR TITLE
turbouncompress64 call bits64 (issue #2)

### DIFF
--- a/include/turbocompression.h
+++ b/include/turbocompression.h
@@ -158,7 +158,7 @@ inline const uint8_t *turbouncompress64(const uint8_t *in, uint64_t *out,
   in += sizeof(m);
   memcpy(&M, in, sizeof(M));
   in += sizeof(M);
-  int b = bits(static_cast<uint64_t>(M - m));
+  int b = bits64(static_cast<uint64_t>(M - m));
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif


### PR DESCRIPTION
Calling bits() instead of bits64() yields an incorrect output when the
difference between the maximum and the minimum (M and m) requires more
than 32 bits.
This incorrect value makes turbouncompress64 to pick the incorrect
unpack function corrupting the whole array.

The fix consists in call bits64(). (issue #2)